### PR TITLE
Added shader material

### DIFF
--- a/ThreePlus/Classes/Material.cs
+++ b/ThreePlus/Classes/Material.cs
@@ -14,7 +14,7 @@ namespace ThreePlus
 
         #region members
 
-        public enum Types { None, Basic, Lambert, Standard, Phong, Toon, Physical, Normal, Depth, Shadow };
+        public enum Types { None, Basic, Lambert, Standard, Phong, Toon, Physical, Normal, Depth, Shadow, Shader };
 
         protected bool isDefault = true;
 
@@ -76,6 +76,9 @@ namespace ThreePlus
         protected double opacityIor = 1.5;
         protected double refractionRatio = 1.5;
 
+        protected bool hasShader = false;
+        protected Shader shader = null;
+
         #endregion
 
         #region constructors
@@ -131,9 +134,9 @@ namespace ThreePlus
         public Material(Material material) : base(material)
         {
             this.isDefault = material.isDefault;
-            
-            for (int i = 0; i < material.maps.Length; i++) if(material.maps[i]!=null) this.maps[i] = material.maps[i];
-                for (int i =0;i< material.maps.Length; i++) this.MapNames[i] = material.MapNames[i];
+
+            for (int i = 0; i < material.maps.Length; i++) if (material.maps[i] != null) this.maps[i] = material.maps[i];
+            for (int i = 0; i < material.maps.Length; i++) this.MapNames[i] = material.MapNames[i];
 
             this.materialType = material.materialType;
 
@@ -188,6 +191,8 @@ namespace ThreePlus
             this.hasOpacityIor = material.hasOpacityIor;
             this.opacityIor = material.opacityIor;
             this.refractionRatio = material.refractionRatio;
+
+            this.shader = material.shader; // Not sure if should create a new one (with new uuid)
         }
 
         public static Material ShadowMaterial(Sd.Color color)
@@ -316,6 +321,18 @@ namespace ThreePlus
             return material;
         }
 
+        public static Material ShaderMaterial(Shader shader)
+        {
+            Material material = new Material(false);
+
+            material.type = "MeshShaderMaterial";
+            material.materialType = Types.Shader;
+
+            material.hasShader = true;
+            material.shader = shader;
+
+            return material;
+        }
 
         #endregion
 
@@ -329,7 +346,7 @@ namespace ThreePlus
         public virtual Sd.Bitmap[] Maps
         {
             get { return maps; }
-            }
+        }
 
         public virtual Types MaterialType
         {
@@ -376,7 +393,7 @@ namespace ThreePlus
 
         public virtual bool HasTextureMap
         {
-            get { return (Maps[0]!=null); }
+            get { return (Maps[0] != null); }
         }
 
         public virtual string TextureMapName
@@ -387,7 +404,7 @@ namespace ThreePlus
         public virtual Sd.Bitmap TextureMap
         {
             set { maps[0] = new Sd.Bitmap(value); }
-            get 
+            get
             {
                 if (maps[0] != null)
                 {
@@ -1267,6 +1284,23 @@ namespace ThreePlus
             get { return refractionRatio; }
         }
 
+        #region 26 | SHADER
+        public virtual bool HasShader
+        {
+            get
+            {
+                return shader != null;
+            }
+        }
+        public virtual Shader Shader
+        {
+            get
+            {
+                return shader;
+            }
+        }
+        #endregion
+
         #endregion
 
         #region methods
@@ -1284,7 +1318,7 @@ namespace ThreePlus
         public void SetBumpMap(Sd.Bitmap map, double intensity = 1.0)
         {
             this.bumpIntensity = intensity;
-            if(map!=null) this.BumpMap = new Sd.Bitmap(map);
+            if (map != null) this.BumpMap = new Sd.Bitmap(map);
         }
 
         public void SetClearcoatMap(double clearcoat, Sd.Bitmap map = null)
@@ -1312,7 +1346,7 @@ namespace ThreePlus
         {
             this.hasDisplacement = (map != null);
             this.displacementScale = scale;
-            if(map != null)this.DisplacementMap = new Sd.Bitmap(map);
+            if (map != null) this.DisplacementMap = new Sd.Bitmap(map);
         }
 
         public void SetEmissivity(double intensity, Sd.Color color, Sd.Bitmap map = null)
@@ -1403,7 +1437,7 @@ namespace ThreePlus
 
         public override string ToString()
         {
-            return "Material | "+ materialType.ToString();
+            return "Material | " + materialType.ToString();
         }
 
         #endregion

--- a/ThreePlus/Classes/Scene.cs
+++ b/ThreePlus/Classes/Scene.cs
@@ -5,11 +5,11 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-using Sd=System.Drawing;
+using Sd = System.Drawing;
 
 namespace ThreePlus
 {
-    public class Scene:MetaData
+    public class Scene : MetaData
     {
 
         #region members
@@ -26,7 +26,7 @@ namespace ThreePlus
         public Axes Axes = new Axes();
 
         public List<Model> Models = new List<Model>();
-        public List<Camera> Cameras = new List<Camera> {new Camera() };
+        public List<Camera> Cameras = new List<Camera> { new Camera() };
         protected List<Light> lights = new List<Light>();
         public List<Script> Scripts = new List<Script>();
 
@@ -37,14 +37,14 @@ namespace ThreePlus
 
         #region constructors
 
-        public Scene():base()
+        public Scene() : base()
         {
             this.type = "Scene";
             this.objectType = "Scene";
             this.name = "Scene";
         }
 
-        public Scene(Scene scene):base(scene)
+        public Scene(Scene scene) : base(scene)
         {
             this.Grid = new Grid(scene.Grid);
             this.Axes = new Axes(scene.Axes);
@@ -66,7 +66,6 @@ namespace ThreePlus
             {
                 this.Scripts.Add(new Script(script));
             }
-
             this.Environment = new Environment(scene.Environment);
             this.Atmosphere = new Atmosphere(scene.Atmosphere);
 
@@ -75,7 +74,7 @@ namespace ThreePlus
 
             this.hasShadows = scene.hasShadows;
             this.shadowThreshold = scene.shadowThreshold;
-    }
+        }
 
         #endregion
 
@@ -87,6 +86,14 @@ namespace ThreePlus
             {
                 foreach (Model model in this.Models) if (model.IsCurve) return true;
                 return false;
+            }
+        }
+
+        public virtual bool HasShaders
+        {
+            get
+            {
+                return Models.Any(m => m.Material.MaterialType == Material.Types.Shader);
             }
         }
 
@@ -112,11 +119,12 @@ namespace ThreePlus
 
         public bool ContainsSpotLights
         {
-            get {
+            get
+            {
                 bool isType = false;
-                foreach(Light light in lights)
+                foreach (Light light in lights)
                 {
-                    if(light.LightType == Light.Types.Spot)
+                    if (light.LightType == Light.Types.Spot)
                     {
                         isType = true;
                         break;
@@ -162,7 +170,7 @@ namespace ThreePlus
                 hasShadows = true;
                 if (light.Threshold > this.shadowThreshold) shadowThreshold = light.Threshold;
             }
-                lights.Add(new Light(light));
+            lights.Add(new Light(light));
         }
 
         #endregion
@@ -171,10 +179,11 @@ namespace ThreePlus
 
         public override string ToString()
         {
-            return "Image(m:" + this.Models.Count + " l:" + this.lights.Count+ ")";
+            return "Image(m:" + this.Models.Count + " l:" + this.lights.Count + ")";
         }
 
         #endregion
 
     }
 }
+

--- a/ThreePlus/Classes/Shader.cs
+++ b/ThreePlus/Classes/Shader.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ThreePlus
+{
+    public class Shader : SceneObject
+    {
+
+        #region members 
+        protected string vertexShaderCode = string.Empty;
+        protected string fragmentShaderCode = string.Empty;
+        protected List<KeyValuePair<string, object>> uniforms = null;
+        #endregion
+
+        #region constructors
+
+        public Shader() : base()
+        {
+            this.type = "Shader";
+        }
+
+        public Shader(Shader script) : base(script)
+        {
+            this.vertexShaderCode = script.vertexShaderCode;
+            this.fragmentShaderCode = script.fragmentShaderCode;
+            this.uniforms = new List<KeyValuePair<string, object>>(script.uniforms);
+        }
+
+        public Shader(string vertexShaderCode, string fragmentShaderCode) : base()
+        {
+            this.type = "Shader";
+
+            this.vertexShaderCode = vertexShaderCode;
+            this.fragmentShaderCode = fragmentShaderCode;
+        }
+        public Shader(string vertexShaderCode, string fragmentShaderCode, List<KeyValuePair<string, object>> uniforms) : base()
+        {
+            this.type = "Shader";
+
+            this.vertexShaderCode = vertexShaderCode;
+            this.fragmentShaderCode = fragmentShaderCode;
+            this.uniforms = uniforms;
+        }
+        #endregion
+
+        #region properties
+
+        public virtual string VertexShaderCode
+        {
+            get { return vertexShaderCode; }
+        }
+        public virtual string FragmentShaderCode
+        {
+            get { return fragmentShaderCode; }
+        }
+        public bool HasUniforms
+        {
+            get
+            {
+                return uniforms != null && uniforms.Count > 0;
+            }
+        }
+        public List<KeyValuePair<string, object>> Uniforms
+        {
+            get { return uniforms; }
+        }
+
+        #endregion
+
+        #region methods
+
+
+
+        #endregion
+
+        #region overrides
+
+        public override string ToString()
+        {
+            return "Shader";
+        }
+
+        #endregion
+
+
+
+    }
+}
+

--- a/ThreePlus/Components/Materials/GH_MaterialShader.cs
+++ b/ThreePlus/Components/Materials/GH_MaterialShader.cs
@@ -1,0 +1,128 @@
+﻿using Grasshopper.Kernel;
+using Grasshopper.Kernel.Types;
+using Rhino.Geometry;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+
+namespace ThreePlus.Components.Materials
+{
+    public class GH_MaterialShader : GH_Component, IGH_VariableParameterComponent
+    {
+        public GH_MaterialShader()
+          : base("Shader Material", "Shader Material",
+              "This material can create shaders written in GLSL that runs on the GPU.",
+              Constants.ShortName, "Materials")
+        {
+        }
+
+        public override GH_Exposure Exposure
+        {
+            get { return GH_Exposure.primary; }
+        }
+
+        protected override void RegisterInputParams(GH_Component.GH_InputParamManager pManager)
+        {
+            pManager.AddGenericParameter("Model", "M", "A Model, Mesh, or Brep", GH_ParamAccess.item);
+            pManager.AddTextParameter("Vertex Code", "V", "The vertex shader code in GLSL.", GH_ParamAccess.item);
+            pManager.AddTextParameter("Fragment Code", "F", "The fragment shader code in GLSL.", GH_ParamAccess.item);
+
+        }
+
+        protected override void RegisterOutputParams(GH_Component.GH_OutputParamManager pManager)
+        {
+            pManager.AddGenericParameter("Model", "M", "The updated Model", GH_ParamAccess.item);
+        }
+
+        protected override void SolveInstance(IGH_DataAccess DA)
+        {
+
+            IGH_Goo goo = null;
+            if (!DA.GetData(0, ref goo)) return;
+
+            Model model = null;
+            if (goo.CastTo<Model>(out model))
+            {
+                model = new Model(model);
+            }
+            else
+            {
+                model = goo.ToModel();
+            }
+
+            string vertexCode = string.Empty;
+            DA.GetData(1, ref vertexCode);
+
+            string fragmentCode = string.Empty;
+            DA.GetData(2, ref fragmentCode);
+
+            List<KeyValuePair<string, object>> uniforms = null;
+            if (Params.Input.Count > 3)
+            {
+                uniforms = new List<KeyValuePair<string, object>>();
+                for (var i = 3; i < Params.Input.Count; i++)
+                {
+                    object data = null;
+                    if (DA.GetData(i, ref data) && data != null)
+                    {
+                        if (data is IGH_Goo gooData)
+                            data = gooData.ScriptVariable();
+                        uniforms.Add(new KeyValuePair<string, object>(Params.Input[i].NickName, data));
+                    }
+                }
+            }
+
+            Shader shader = new Shader(vertexCode, fragmentCode, uniforms);
+
+            model.Material = Material.ShaderMaterial(shader);
+
+            DA.SetData(0, model);
+        }
+
+        #region IGH_VariableParameterComponent
+        public bool CanInsertParameter(GH_ParameterSide side, int index)
+        {
+            return side == GH_ParameterSide.Input && index > 2;
+        }
+
+        public bool CanRemoveParameter(GH_ParameterSide side, int index)
+        {
+            return side == GH_ParameterSide.Input && index > 2;
+        }
+
+        public IGH_Param CreateParameter(GH_ParameterSide side, int index)
+        {
+            index -= 2;
+            return new Grasshopper.Kernel.Parameters.Param_GenericObject()
+            {
+                Name = "Uniform" + index,
+                NickName = "u" + index,
+                Description = "Uniform data to access from shader code. Change its nickname to change its variable name.",
+                Access = GH_ParamAccess.item
+            };
+        }
+
+        public bool DestroyParameter(GH_ParameterSide side, int index)
+        {
+            return true;
+        }
+
+        public void VariableParameterMaintenance()
+        {
+        }
+        #endregion
+
+        protected override System.Drawing.Bitmap Icon
+        {
+            get
+            {
+                return null;
+            }
+        }
+
+        public override Guid ComponentGuid
+        {
+            get { return new Guid("8e26e402-52a8-4391-ac24-495c93b071dd"); }
+        }
+    }
+}

--- a/ThreePlus/Extensions/ObjToJavascript.cs
+++ b/ThreePlus/Extensions/ObjToJavascript.cs
@@ -60,7 +60,7 @@ namespace ThreePlus
                     output.AppendLine("<script src=\"js/LightProbeGenerator.js\"></script>");//
                     output.AppendLine("<script src=\"js/LightProbeHelper.js\"></script>");//
                 }
-                if(input.Sky.HasSky) output.AppendLine("<script src=\"js/Sky.js\"></script>");
+                if (input.Sky.HasSky) output.AppendLine("<script src=\"js/Sky.js\"></script>");
             }
             else
             {
@@ -87,21 +87,36 @@ namespace ThreePlus
                     output.AppendLine("<script src=\"https://cdn.jsdelivr.net/npm/three@0.136.0/examples/js/helpers/LightProbeHelper.js\" ></script>");
                 }
 
-                if (input.HasCurves) 
+                if (input.HasCurves)
                 {
-                //output.AppendLine("<script src=\"https://cdn.jsdelivr.net/npm/three@0.136.0/examples/js/utils/GeometryUtils.js\" ></script>");
-                output.AppendLine("<script src=\"https://cdn.jsdelivr.net/npm/three@0.136.0/examples/js/lines/LineSegmentsGeometry.js\" ></script>");
-                output.AppendLine("<script src=\"https://cdn.jsdelivr.net/npm/three@0.136.0/examples/js/lines/LineSegments2.js\" ></script>");
-                output.AppendLine("<script src=\"https://cdn.jsdelivr.net/npm/three@0.136.0/examples/js/lines/LineGeometry.js\" ></script>");
-                output.AppendLine("<script src=\"https://cdn.jsdelivr.net/npm/three@0.136.0/examples/js/lines/LineMaterial.js\" ></script>");
-                output.AppendLine("<script src=\"https://cdn.jsdelivr.net/npm/three@0.136.0/examples/js/lines/Line2.js\" ></script>");
+                    //output.AppendLine("<script src=\"https://cdn.jsdelivr.net/npm/three@0.136.0/examples/js/utils/GeometryUtils.js\" ></script>");
+                    output.AppendLine("<script src=\"https://cdn.jsdelivr.net/npm/three@0.136.0/examples/js/lines/LineSegmentsGeometry.js\" ></script>");
+                    output.AppendLine("<script src=\"https://cdn.jsdelivr.net/npm/three@0.136.0/examples/js/lines/LineSegments2.js\" ></script>");
+                    output.AppendLine("<script src=\"https://cdn.jsdelivr.net/npm/three@0.136.0/examples/js/lines/LineGeometry.js\" ></script>");
+                    output.AppendLine("<script src=\"https://cdn.jsdelivr.net/npm/three@0.136.0/examples/js/lines/LineMaterial.js\" ></script>");
+                    output.AppendLine("<script src=\"https://cdn.jsdelivr.net/npm/three@0.136.0/examples/js/lines/Line2.js\" ></script>");
                 }
 
-                if(input.Sky.HasSky)
+                if (input.Sky.HasSky)
                 {
                     output.AppendLine("<script src=\"https://cdn.jsdelivr.net/npm/three@0.136.0/examples/js/objects/Sky.js\" ></script>");
                 }
             }
+
+            if (input.HasShaders)
+            {
+                for (int i = 0; i < input.Models.Count; i++)
+                {
+                    Model model = input.Models[i];
+                    if (model.Material.HasShader)
+                    {
+                        Shader shader = model.Material.Shader;
+                        output.AppendLine($"<script type=\"x-shader/x-vertex\" id=\"vertexShader{i}\">{shader.VertexShaderCode}</script>");
+                        output.AppendLine($"<script type=\"x-shader/x-fragment\" id=\"fragmentShader{i}\">{shader.FragmentShaderCode}</script>");
+                    }
+                }
+            }
+
             output.AppendLine("<script type=\"text/javascript\" src=\"app.js\"></script>");
             output.AppendLine("</body>");
             output.AppendLine("</html>");
@@ -132,7 +147,7 @@ namespace ThreePlus
                 output.AppendLine("renderer.shadowMap.enabled = true;");
                 output.AppendLine("renderer.shadowMap.type = THREE.PCFSoftShadowMap;");
             }
-            output.AppendLine(input.Sky.ToJavascript(bbox.Diagonal.Length*1000.0));
+            output.AppendLine(input.Sky.ToJavascript(bbox.Diagonal.Length * 1000.0));
 
             output.AppendLine("document.body.appendChild(renderer.domElement);");
 
@@ -162,7 +177,7 @@ namespace ThreePlus
                 }
                 else if (model.IsCloud)
                 {
-                    if(model.Cloud.HasBitmap)
+                    if (model.Cloud.HasBitmap)
                     {
                         string key = model.Cloud.Map.GetHash(crypt);
                         if (!maps.ContainsKey(key))
@@ -171,7 +186,7 @@ namespace ThreePlus
                             maps.Add(key, name);
                             output.AppendLine(model.Cloud.Map.ToJsObjMap(name));
                         }
-                        model.Cloud.MapName= maps[key];
+                        model.Cloud.MapName = maps[key];
                     }
                 }
             }
@@ -194,7 +209,7 @@ namespace ThreePlus
 
                 if (model.IsCurve)
                 {
-                    output.AppendLine(model.Curve.ToJavascript(index,model.Graphic));
+                    output.AppendLine(model.Curve.ToJavascript(index, model.Graphic));
                     sceneModifiers.AppendLine("lineMat" + index + ".resolution.set(window.innerWidth, window.innerHeight);");
                     output.Append(model.Tangents.ToJavascript(index));
                 }
@@ -216,8 +231,8 @@ namespace ThreePlus
 
                     if (input.HasShadows)
                     {
-                        if (model.Material.DiffuseColor.A > (input.ShadowThreshold*255.0))
-                        { 
+                        if (model.Material.DiffuseColor.A > (input.ShadowThreshold * 255.0))
+                        {
                             output.AppendLine("model" + index + ".castShadow = true;");
                             if (model.Material.MaterialType != Material.Types.Toon) output.AppendLine("model" + index + ".receiveShadow = true;");
                         }
@@ -293,7 +308,7 @@ namespace ThreePlus
             }
             foreach (string ind in tweenIndices)
             {
-                output.AppendLine("var quatStep"+ind+" = 0;");
+                output.AppendLine("var quatStep" + ind + " = 0;");
             }
 
             output.AppendLine("var increment = 0;");
@@ -309,28 +324,28 @@ namespace ThreePlus
                 output.AppendLine("camera.updateProjectionMatrix();");
             }
 
-            foreach(string ind in tweenIndices)
+            foreach (string ind in tweenIndices)
             {
                 output.AppendLine("const matrix" + ind + " = new THREE.Matrix4()");
-                    output.AppendLine("matrix"+ind+".set(mtx" 
-                    + ind + "[mtrx" + ind + "][0],mtx" 
-                    + ind + "[mtrx" + ind + "][1],mtx"
-                    + ind + "[mtrx" + ind + "][2],mtx"
-                    + ind + "[mtrx" + ind + "][3],mtx"
-                    + ind + "[mtrx" + ind + "][4],mtx"
-                    + ind + "[mtrx" + ind + "][5],mtx"
-                    + ind + "[mtrx" + ind + "][6],mtx"
-                    + ind + "[mtrx" + ind + "][7],mtx"
-                    + ind + "[mtrx" + ind + "][8],mtx"
-                    + ind + "[mtrx" + ind + "][9],mtx"
-                    + ind + "[mtrx" + ind + "][10],mtx"
-                    + ind + "[mtrx" + ind + "][11],mtx"
-                    + ind + "[mtrx" + ind + "][12],mtx"
-                    + ind + "[mtrx" + ind + "][13],mtx"
-                    + ind + "[mtrx" + ind + "][14],mtx"
-                    + ind + "[mtrx" + ind + "][15]"
-                    + ");");
-                output.AppendLine("model"+ ind + ".applyMatrix4(matrix" + ind + ");");
+                output.AppendLine("matrix" + ind + ".set(mtx"
+                + ind + "[mtrx" + ind + "][0],mtx"
+                + ind + "[mtrx" + ind + "][1],mtx"
+                + ind + "[mtrx" + ind + "][2],mtx"
+                + ind + "[mtrx" + ind + "][3],mtx"
+                + ind + "[mtrx" + ind + "][4],mtx"
+                + ind + "[mtrx" + ind + "][5],mtx"
+                + ind + "[mtrx" + ind + "][6],mtx"
+                + ind + "[mtrx" + ind + "][7],mtx"
+                + ind + "[mtrx" + ind + "][8],mtx"
+                + ind + "[mtrx" + ind + "][9],mtx"
+                + ind + "[mtrx" + ind + "][10],mtx"
+                + ind + "[mtrx" + ind + "][11],mtx"
+                + ind + "[mtrx" + ind + "][12],mtx"
+                + ind + "[mtrx" + ind + "][13],mtx"
+                + ind + "[mtrx" + ind + "][14],mtx"
+                + ind + "[mtrx" + ind + "][15]"
+                + ");");
+                output.AppendLine("model" + ind + ".applyMatrix4(matrix" + ind + ");");
             }
 
             output.AppendLine("controls.update();");
@@ -348,7 +363,19 @@ namespace ThreePlus
             if (input.AmbientOcclusion.HasAO) output.AppendLine("composer.render();");
             if (input.Outline.HasOutline) output.AppendLine("outline.render(scene,camera);");
 
-            output.AppendLine("increment=increment+"+ input.Camera.Speed + ";");
+            output.AppendLine("increment=increment+" + input.Camera.Speed + ";");
+            if (input.HasShaders)
+            {
+                for (int j = 0; j < input.Models.Count; j++)
+                {
+                    var model = input.Models[j];
+                    if (model.Material.HasShader && model.Material.Shader.HasUniforms)
+                    {
+                        output.AppendLine($"uniforms{j}.uTime.value++;");
+                    }
+                }
+            }
+
             output.AppendLine("};");
             output.AppendLine("animate();");
 
@@ -484,7 +511,7 @@ namespace ThreePlus
             StringBuilder output = new StringBuilder();
             if (input.EnvironmentMode == Environment.EnvironmentModes.CubeMap)
             {
-                if(input.IsIllumination) output.AppendLine("lightProbe.intensity = "+Math.Round(input.CubeMap.Intensity,5)+";");
+                if (input.IsIllumination) output.AppendLine("lightProbe.intensity = " + Math.Round(input.CubeMap.Intensity, 5) + ";");
             }
             return output.ToString();
         }
@@ -502,7 +529,7 @@ namespace ThreePlus
                     output.AppendLine("var envMap = new THREE.TextureLoader().load(\"data:image/png;base64," + input.EnvMap.ToStr() + "\");");
                     output.AppendLine("envMap.mapping = THREE.EquirectangularReflectionMapping;");
 
-                    if (input.IsBackground)output.AppendLine("scene.background = envMap;");
+                    if (input.IsBackground) output.AppendLine("scene.background = envMap;");
                     if (input.IsEnvironment) output.AppendLine("scene.environment = envMap;");
 
                     break;
@@ -553,7 +580,7 @@ namespace ThreePlus
 
             if (input.HasEdges)
             {
-                output.AppendLine("const edges"+index+ " = new THREE.EdgesGeometry(mesh" + index + ", "+ input.EdgeThreshold+");");
+                output.AppendLine("const edges" + index + " = new THREE.EdgesGeometry(mesh" + index + ", " + input.EdgeThreshold + ");");
                 output.AppendLine("const edge" + index + " = new THREE.LineSegments(edges" + index + ", new THREE.LineBasicMaterial({ color:" + input.Graphic.Color.ToStr() + "}));");
                 output.AppendLine("scene.add(edge" + index + ");");
             }
@@ -580,30 +607,30 @@ namespace ThreePlus
 
             if (input.HasSky)
             {
-            output.AppendLine("const sky = new THREE.Sky();");
-            output.AppendLine("const sun = new THREE.Vector3();");
-            output.AppendLine("sky.scale.setScalar("+Math.Ceiling(scale)+");");
-            output.AppendLine("scene.add(sky);");
-            output.AppendLine("const uniforms = sky.material.uniforms;");
-            output.AppendLine("uniforms['turbidity'].value = " + input.Turbidity + ";");
-            output.AppendLine("uniforms['rayleigh'].value = " + input.Rayleigh + ";");
-            output.AppendLine("uniforms['mieCoefficient'].value = " + input.Coefficient + ";");
-            output.AppendLine("uniforms['mieDirectionalG'].value = " + input.Directional + ";");
+                output.AppendLine("const sky = new THREE.Sky();");
+                output.AppendLine("const sun = new THREE.Vector3();");
+                output.AppendLine("sky.scale.setScalar(" + Math.Ceiling(scale) + ");");
+                output.AppendLine("scene.add(sky);");
+                output.AppendLine("const uniforms = sky.material.uniforms;");
+                output.AppendLine("uniforms['turbidity'].value = " + input.Turbidity + ";");
+                output.AppendLine("uniforms['rayleigh'].value = " + input.Rayleigh + ";");
+                output.AppendLine("uniforms['mieCoefficient'].value = " + input.Coefficient + ";");
+                output.AppendLine("uniforms['mieDirectionalG'].value = " + input.Directional + ";");
 
-            output.AppendLine("const phi = THREE.MathUtils.degToRad(90 - " + input.Altitude + ");");
-            output.AppendLine("const theta = THREE.MathUtils.degToRad(" + input.Azimuth + ");");
-            output.AppendLine("sun.setFromSphericalCoords(1, phi, theta);");
+                output.AppendLine("const phi = THREE.MathUtils.degToRad(90 - " + input.Altitude + ");");
+                output.AppendLine("const theta = THREE.MathUtils.degToRad(" + input.Azimuth + ");");
+                output.AppendLine("sun.setFromSphericalCoords(1, phi, theta);");
 
-            output.AppendLine("uniforms['sunPosition'].value.copy(sun);");
+                output.AppendLine("uniforms['sunPosition'].value.copy(sun);");
 
-            output.AppendLine("renderer.toneMapping = THREE.ACESFilmicToneMapping;");
-            output.AppendLine("renderer.toneMappingExposure = " + Math.Round(input.Exposure, 5) + ";");
+                output.AppendLine("renderer.toneMapping = THREE.ACESFilmicToneMapping;");
+                output.AppendLine("renderer.toneMappingExposure = " + Math.Round(input.Exposure, 5) + ";");
 
-            if (input.Environment)
-            {
-                output.AppendLine("const pmremGenerator = new THREE.PMREMGenerator(renderer);");
-                output.AppendLine("scene.environment = pmremGenerator.fromScene(sky).texture;");
-            }
+                if (input.Environment)
+                {
+                    output.AppendLine("const pmremGenerator = new THREE.PMREMGenerator(renderer);");
+                    output.AppendLine("scene.environment = pmremGenerator.fromScene(sky).texture;");
+                }
                 //output.AppendLine("const sunlight = new THREE.DirectionalLight("+input.SunColor.ToStr()+", 1.0);");
                 //output.AppendLine("sunlight.position.set(sun.x, sun.y, sun.z);");
                 //output.AppendLine("scene.add(sunlight);");
@@ -620,7 +647,7 @@ namespace ThreePlus
             if (input.Show)
             {
                 output.AppendLine("const axes = new THREE.AxesHelper(" + input.Scale + ");");
-                output.AppendLine("axes.setColors ( "+input.YAxis.ToStr() +", "+input.ZAxis.ToStr() + ", "+input.XAxis.ToStr()+" );");
+                output.AppendLine("axes.setColors ( " + input.YAxis.ToStr() + ", " + input.ZAxis.ToStr() + ", " + input.XAxis.ToStr() + " );");
                 output.AppendLine("scene.add(axes);");
             }
 
@@ -660,7 +687,7 @@ namespace ThreePlus
                 output.AppendLine("const camera = new THREE.PerspectiveCamera(" + input.FOV + ", window.innerWidth / window.innerHeight, " + input.Near + "," + input.Far + ");");
             }
 
-            if(input.IsAnimated)
+            if (input.IsAnimated)
             {
                 output.AppendLine("camera.position.set(" + input.Tweens[0].From.ToStr() + ");");
                 output.AppendLine("camera.lookAt (new THREE.Vector3(" + input.Tweens[0].To.X + "," + input.Tweens[0].To.Z + "," + input.Tweens[0].To.Y + "));");
@@ -678,8 +705,8 @@ namespace ThreePlus
             }
             else
             {
-            output.AppendLine("camera.position.set(" + input.Position.ToStr() + ");");
-            output.AppendLine("camera.lookAt (new THREE.Vector3(" + input.Target.X + "," + input.Target.Z + "," + input.Target.Y + "));");
+                output.AppendLine("camera.position.set(" + input.Position.ToStr() + ");");
+                output.AppendLine("camera.lookAt (new THREE.Vector3(" + input.Target.X + "," + input.Target.Z + "," + input.Target.Y + "));");
             }
 
             return output.ToString();
@@ -767,12 +794,65 @@ namespace ThreePlus
                 case Material.Types.Depth:
                     output.AppendLine(starter + "MeshDepthMaterial();");
                     break;
+                case Material.Types.Shader:
+                    string uniforms = string.Empty;
+                    if (input.HasShader && input.Shader.HasUniforms)
+                    {
+                        output.AppendLine($"const uniforms{index} = {{ {input.ToJsShaderUniforms(index)} }}"); // k
+                        uniforms = $"uniforms: uniforms{index}, ";
+                    }
+
+                    output.AppendLine(starter + "ShaderMaterial( { " + uniforms +
+                    $"vertexShader: document.getElementById('vertexShader{index}').textContent, " +
+                    $"fragmentShader: document.getElementById('fragmentShader{index}').textContent " +
+                    "} ); ");
+                    break;
             }
 
             if (input.IsWireframe) output.AppendLine("material" + index + ".wireframe = true;");
             if (input.IsFlatShaded) output.AppendLine("material" + index + ".flatShading = true;");
 
             return output.ToString();
+        }
+
+        public static string ToJsShaderUniforms(this Material input, string index)
+        {
+            if (input.HasShader && input.Shader.HasUniforms)
+            {
+                var uniforms = new List<string>();
+                uniforms.Add("uTime: { value: 0 }"); // Default uniform
+                foreach (var kvp in input.Shader.Uniforms)
+                {
+                    uniforms.Add($"{kvp.Key}: {{ value: {ToJsShaderUniformValue(kvp.Value)} }}");
+                }
+                return string.Join(", ", uniforms);
+            }
+            else
+            {
+                return string.Empty;
+            }
+
+            string ToJsShaderUniformValue(object obj)
+            {
+                if (obj is Rg.Point3d p3d)
+                {
+                    return $"new THREE.Vector3({p3d.X}, {p3d.Y}, {p3d.Z})";
+                }
+                else if (obj is Rg.Vector3d v3d)
+                {
+                    return $"new THREE.Vector3({v3d.X}, {v3d.Y}, {v3d.Z})";
+                }
+                else if (obj is Sd.Color color)
+                {
+                    return $"new THREE.Color(\"rgb({color.R}, {color.G}, {color.B})\")";
+                }
+
+                //TODO support other formats
+
+                return obj.ToString();
+            }
+
+
         }
 
         public static string ToJsClearcoat(this Material input, string index)
@@ -875,7 +955,7 @@ namespace ThreePlus
             output.Append(", opacity : " + input.DiffuseColor.ToStrOpacity());
             if (input.HasOpacityMap) output.Append(", alphaMap : " + input.OpacityMapName);
             output.Append(", transparent: " + input.IsTransparent.ToString().ToLower());
-            if(input.HasOpacityIor) output.Append(", ior: " + input.OpacityIor);
+            if (input.HasOpacityIor) output.Append(", ior: " + input.OpacityIor);
             if (input.HasOpacityIorMap) output.Append(", transmission : " + input.Transmission);
             if (input.HasOpacityIorMap) output.Append(", transmissionMap : " + input.TransmissionMapName);
 
@@ -918,7 +998,7 @@ namespace ThreePlus
                     if (input.HasHelper) output.AppendLine(helperStart + "SpotLightHelper(" + name + ", " + input.HelperColor.ToStr() + " );");
                     break;
             }
-            if ((input.HasHelper) &(input.LightType!= Light.Types.Ambient)) output.AppendLine("scene.add(" + hName + ");");
+            if ((input.HasHelper) & (input.LightType != Light.Types.Ambient)) output.AppendLine("scene.add(" + hName + ");");
             return output.ToString();
         }
 
@@ -958,15 +1038,15 @@ namespace ThreePlus
             output.AppendLine("const positions" + index + " = new Float32Array( [" + string.Join(",", points.Values) + "] );");
             output.AppendLine("const colors" + index + " = new Float32Array( [" + string.Join(",", colors.Values) + "] );");
             //if(input.IsSprite)output.AppendLine("const scales" + index + " = new Float32Array( [" + string.Join(",", input.Scales) + "] );");
-            
+
             output.AppendLine(name + ".setAttribute( 'position', new THREE.BufferAttribute( positions" + index + ", 3 ) );");
             output.AppendLine(name + ".setAttribute( 'color', new THREE.BufferAttribute( colors" + index + ", 3 ) );");
             //if (input.IsSprite) output.AppendLine(name + ".setAttribute( 'scale', new THREE.BufferAttribute( scales" + index + ", 1 ) );");
 
-                output.Append("const material" + index + " = new THREE.PointsMaterial( { size: " + Math.Round(input.Scale, 5) + ", depthTest: true, transparent: true, color: 0xffffff, vertexColors: true ");
-                if (input.HasBitmap) output.Append(", map: "+ input.MapName + ", alphaMap: " + input.MapName+ ", alphaTest:"+Math.Round(input.Threshold,5));
-                    output.AppendLine(" } );");
-                output.AppendLine("const model" + index + " = new THREE.Points( " + name + ", material" + index + " );");
+            output.Append("const material" + index + " = new THREE.PointsMaterial( { size: " + Math.Round(input.Scale, 5) + ", depthTest: true, transparent: true, color: 0xffffff, vertexColors: true ");
+            if (input.HasBitmap) output.Append(", map: " + input.MapName + ", alphaMap: " + input.MapName + ", alphaTest:" + Math.Round(input.Threshold, 5));
+            output.AppendLine(" } );");
+            output.AppendLine("const model" + index + " = new THREE.Points( " + name + ", material" + index + " );");
 
             return output.ToString();
         }
@@ -999,12 +1079,12 @@ namespace ThreePlus
             }
             else
             {
-                output.Append(", color: " + graphic.Color.ToStr()+ ", vertexColors: false");
+                output.Append(", color: " + graphic.Color.ToStr() + ", vertexColors: false");
             }
 
             if (graphic.DashLength > 0)
             {
-                output.Append(", dashed: true, dashSize: "+graphic.DashLength+", gapSize: "+graphic.GapLength);
+                output.Append(", dashed: true, dashSize: " + graphic.DashLength + ", gapSize: " + graphic.GapLength);
             }
             else
             {
@@ -1016,16 +1096,16 @@ namespace ThreePlus
             if (graphic.HasColors)
             {
                 Parallel.For(0, count, k =>
-            {
-                int m = k % graphic.Colors.Count;
-                colors[k] = graphic.Colors[m].ToStrArray();
-            }
+                {
+                    int m = k % graphic.Colors.Count;
+                    colors[k] = graphic.Colors[m].ToStrArray();
+                }
             );
                 output.AppendLine("const colors" + index + " = new Float32Array( [" + string.Join(",", colors.Values) + "] );");
                 output.AppendLine(name + ".setColors( colors" + index + " );");
             }
 
-            output.AppendLine("const model"+index+" = new THREE.Line2( "+name+", lineMat" + index +" );");
+            output.AppendLine("const model" + index + " = new THREE.Line2( " + name + ", lineMat" + index + " );");
             output.AppendLine("model" + index + ".computeLineDistances();");
 
             return output.ToString();

--- a/ThreePlus/ThreePlus.csproj
+++ b/ThreePlus/ThreePlus.csproj
@@ -66,6 +66,7 @@
     <Compile Include="Classes\PointCloud.cs" />
     <Compile Include="Classes\PostProcessing\AmbientOcclusion.cs" />
     <Compile Include="Classes\PostProcessing\Outline.cs" />
+    <Compile Include="Classes\Shader.cs" />
     <Compile Include="Classes\Sky.cs" />
     <Compile Include="Components\Assets\GH_Assets_CubeMap.cs" />
     <Compile Include="Components\Assets\GH_Assets_CubeMaps.cs" />
@@ -82,6 +83,7 @@
     <Compile Include="Components\Helpers\GH_DisplayLight.cs" />
     <Compile Include="Components\Lights\GH_LightShadows.cs" />
     <Compile Include="Components\Graphics\GH_GraphicsPoints.cs" />
+    <Compile Include="Components\Materials\GH_MaterialShader.cs" />
     <Compile Include="Components\Materials\GH_MaterialShadow.cs" />
     <Compile Include="Components\Materials\Maps\GH_Map_Edges.cs" />
     <Compile Include="Components\Materials\Maps\GH_Map_Metalness.cs" />
@@ -894,8 +896,7 @@
   </Target>
   -->
   <PropertyGroup>
-    <PostBuildEvent>Copy "$(TargetPath)" "$(TargetDir)$(ProjectName).gha"
-Erase "$(TargetPath)"</PostBuildEvent>
+    <PostBuildEvent>copy  /Y "$(TargetDir)$(ProjectName).dll" "$(USERPROFILE)\AppData\Roaming\Grasshopper\Libraries\$(ProjectName).gha"</PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
     <FallbackCulture>en-US</FallbackCulture>


### PR DESCRIPTION
Here is a basic implementation for shader material.

![image](https://user-images.githubusercontent.com/14053237/155843448-6f5a70f2-3021-4e79-ad97-c54d43bbf921.png)
 
It can be extended once you pass this implementation, mainly to add new uniform types. 

I think you have to implement your Script object first in order to be able to update uniform values since Render().

Sample file (is more a dev testing file that a sample file):
[ThreePlus-Materials-11_Shader.zip](https://github.com/interopxyz/ThreePlus/files/8146598/ThreePlus-Materials-11_Shader.zip)

<sub><sup>
It has been a headache to synchronize my project with yours because I downloaded the project as a ZIP and your VS solution is inside a folder. I was able to fix it by re-downloading the project, this time with "Open with Visual Studio" and the cloning was successful. I've probably used a bad habit but it has worked for me so far. However when I copied and pasted my changes into the new properly cloned project, there was a formatting adjustment adding unnecessary spaces. Keep this in mind when reviewing the changes.
</sub></sup>
